### PR TITLE
Add PC declaration and handling in extractor and tracing logic

### DIFF
--- a/horus/analyzer/datalog/lib/edb.dl
+++ b/horus/analyzer/datalog/lib/edb.dl
@@ -1,5 +1,6 @@
 
 .decl def(step:number, opcode:Opcode, transaction_hash:symbol)
+.decl pc(step:number, pc:number, contract:Address, transaction_hash:symbol, opcode:Opcode)
 .decl use(step1:number, step2:number, transaction_hash:symbol)
 .decl arithmetic(step:number, opcode:Opcode, first_operand:Value, second_operand:Value, arithmetic_result:Value, evm_result:Value)
 .decl storage(step:number, opcode:Opcode, transaction_hash:symbol, caller:Address, contract:Address, storage_index:Value, storage_value:Value, depth:number)
@@ -13,6 +14,7 @@
 .decl transaction(transaction_hash:symbol, transaction_index:number, block_number:number, from:Address, to:Address, input_data:symbol, gas_used:number, gas_limit:number, status:number)
 
 .input def
+.input pc
 .input use
 .input arithmetic
 .input storage

--- a/horus/extractor/__init__.py
+++ b/horus/extractor/__init__.py
@@ -22,6 +22,7 @@ class Extractor:
 
         if not compress:
             def_facts           = open(facts_folder+"/def.facts",           "a")
+            pc_facts            = open(facts_folder+"/pc.facts",            "a")
             use_facts           = open(facts_folder+"/use.facts",           "a")
             arithmetic_facts    = open(facts_folder+"/arithmetic.facts",    "a")
             storage_facts       = open(facts_folder+"/storage.facts",       "a")
@@ -56,6 +57,13 @@ class Extractor:
                     print(str(step)+" \t "+str(trace[step]["pc"])+" \t "+trace[step]["op"].ljust(10)+"\t "+str(trace[step]["gas"]).ljust(10)+" \t "+str(trace[step]["gasCost"]).ljust(10)+" \t "+str(trace[step]["depth"])+" \t "+str(call_flow_analysis.get_caller())+(" \t "+"[Error]" if "error" in trace[step] else ""))
                 else:
                     print(str(step)+" \t "+trace[step]["op"].ljust(10)+" \t "+str(trace[step]["depth"])+" \t "+str(trace[step]["contract"])+(" \t "+"[Error]" if "error" in trace[step] else ""))
+
+            # PC facts — one row per trace step when Geth provides pc
+            if "pc" in trace[step]:
+                if compress:
+                    in_memory_zip.append(facts_folder+"/pc.facts", "%d\t%d\t%s\t%s\t%s\r\n" % (step, trace[step]["pc"], trace[step]["contract"], transaction["hash"], trace[step]["op"]))
+                else:
+                    pc_facts.write("%d\t%d\t%s\t%s\t%s\r\n" % (step, trace[step]["pc"], trace[step]["contract"], transaction["hash"], trace[step]["op"]))
 
             # Use facts
             if trace[step]["op"] in [
@@ -264,6 +272,7 @@ class Extractor:
 
         if not compress:
             def_facts.close()
+            pc_facts.close()
             use_facts.close()
             arithmetic_facts.close()
             storage_facts.close()
@@ -301,6 +310,7 @@ class Extractor:
         if compress:
             in_memory_zip = InMemoryZip()
             in_memory_zip.append(facts_folder+"/def.facts", "")
+            in_memory_zip.append(facts_folder+"/pc.facts", "")
             in_memory_zip.append(facts_folder+"/use.facts", "")
             in_memory_zip.append(facts_folder+"/arithmetic.facts", "")
             in_memory_zip.append(facts_folder+"/storage.facts", "")
@@ -396,6 +406,7 @@ class Extractor:
         if compress:
             in_memory_zip = InMemoryZip()
             in_memory_zip.append(facts_folder+"/def.facts", "")
+            in_memory_zip.append(facts_folder+"/pc.facts", "")
             in_memory_zip.append(facts_folder+"/use.facts", "")
             in_memory_zip.append(facts_folder+"/arithmetic.facts", "")
             in_memory_zip.append(facts_folder+"/storage.facts", "")

--- a/horus/extractor/evm_tracing.js
+++ b/horus/extractor/evm_tracing.js
@@ -4,34 +4,34 @@
   step: function(log, db) {
     switch(log.op.toString()) {
       case "ADD": case "SUB": case "MUL":
-        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(1), log.stack.peek(0)], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError()});
+        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(1), log.stack.peek(0)], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError(), "pc": log.getPC()});
         break;
       case "SSTORE":
-        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(1), log.stack.peek(0)], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError()});
+        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(1), log.stack.peek(0)], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError(), "pc": log.getPC()});
         break;
       case "SLOAD":
-        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(0)], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError()});
+        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(0)], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError(), "pc": log.getPC()});
         break;
       case "CREATE": case "CREATE2":
-        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(2), log.stack.peek(1), log.stack.peek(0)], "memory": log.stack.peek(2).valueOf() > 0 ? toHex(log.memory.slice(log.stack.peek(1).valueOf(), log.stack.peek(1).valueOf() + log.stack.peek(2).valueOf())) : "", "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError()});
+        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(2), log.stack.peek(1), log.stack.peek(0)], "memory": log.stack.peek(2).valueOf() > 0 ? toHex(log.memory.slice(log.stack.peek(1).valueOf(), log.stack.peek(1).valueOf() + log.stack.peek(2).valueOf())) : "", "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError(), "pc": log.getPC()});
         break;
       case "CALL": case "CALLCODE":
-        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(4), log.stack.peek(3), log.stack.peek(2), log.stack.peek(1), log.stack.peek(0)], "memory": log.stack.peek(4).valueOf() > 0 ? toHex(log.memory.slice(log.stack.peek(3).valueOf(), log.stack.peek(3).valueOf() + log.stack.peek(4).valueOf())) : "", "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError()});
+        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(4), log.stack.peek(3), log.stack.peek(2), log.stack.peek(1), log.stack.peek(0)], "memory": log.stack.peek(4).valueOf() > 0 ? toHex(log.memory.slice(log.stack.peek(3).valueOf(), log.stack.peek(3).valueOf() + log.stack.peek(4).valueOf())) : "", "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError(), "pc": log.getPC()});
         break;
       case "DELEGATECALL": case "STATICCALL":
-        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(3), log.stack.peek(2), log.stack.peek(1), log.stack.peek(0)], "memory": log.stack.peek(3).valueOf() > 0 ? toHex(log.memory.slice(log.stack.peek(2).valueOf(), log.stack.peek(2).valueOf() + log.stack.peek(3).valueOf())) : "", "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError()});
+        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(3), log.stack.peek(2), log.stack.peek(1), log.stack.peek(0)], "memory": log.stack.peek(3).valueOf() > 0 ? toHex(log.memory.slice(log.stack.peek(2).valueOf(), log.stack.peek(2).valueOf() + log.stack.peek(3).valueOf())) : "", "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError(), "pc": log.getPC()});
         break;
       case "SELFDESTRUCT": case "SUICIDE":
-        this.structLogs.push({"op": log.op.toString(), "stack": [db.getBalance(log.contract.getAddress()), log.stack.peek(0)], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError()});
+        this.structLogs.push({"op": log.op.toString(), "stack": [db.getBalance(log.contract.getAddress()), log.stack.peek(0)], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError(), "pc": log.getPC()});
         break;
       case "LOG3":
-        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(4), log.stack.peek(3), log.stack.peek(2), log.stack.peek(1), log.stack.peek(0)], "memory": log.stack.peek(1).valueOf() > 0 ? toHex(log.memory.slice(log.stack.peek(0).valueOf(), log.stack.peek(0).valueOf() + log.stack.peek(1).valueOf())) : "", "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError()});
+        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(4), log.stack.peek(3), log.stack.peek(2), log.stack.peek(1), log.stack.peek(0)], "memory": log.stack.peek(1).valueOf() > 0 ? toHex(log.memory.slice(log.stack.peek(0).valueOf(), log.stack.peek(0).valueOf() + log.stack.peek(1).valueOf())) : "", "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError(), "pc": log.getPC()});
         break;
       case "SHA3":
-        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(1), log.stack.peek(0)], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError()});
+        this.structLogs.push({"op": log.op.toString(), "stack": [log.stack.peek(1), log.stack.peek(0)], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError(), "pc": log.getPC()});
         break;
       default:
-        this.structLogs.push({"op": log.op.toString(), "stack": log.stack.length() > 0 ? [log.stack.peek(0)] : [], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError()});
+        this.structLogs.push({"op": log.op.toString(), "stack": log.stack.length() > 0 ? [log.stack.peek(0)] : [], "depth": log.getDepth(), "contract": toHex(log.contract.getAddress()), "error": log.getError(), "pc": log.getPC()});
     }
   },
 


### PR DESCRIPTION
This creates a new Souffle relation that allows matching to a statement's program counter value. By adding a new statement instead of updating the previous statements, it remains backwards compatible with previously written queries.